### PR TITLE
feat : make the URLs provided by the bot clickable

### DIFF
--- a/src/ai/agent.ts
+++ b/src/ai/agent.ts
@@ -91,7 +91,7 @@ export class Agent {
       "\nPrioritize function calls over clarifying questions. Do not ask the user for permission to execute functions." +
       "\nKeep responses concise—under 2000 characters for Discord." +
       "\nMaintain a friendly, professional tone, and feel free to add a bit of light humor occasionally." + 
-      "\nAdd https:// in front of links if they are missing it, so the user can click the URLs directly.";
+      "\nYou should check that all the links are started with https://, modify it if they are missing it, so the user can click the URLs directly.";
     return systemInstruction;
   }
 

--- a/src/ai/agent.ts
+++ b/src/ai/agent.ts
@@ -85,12 +85,13 @@ export class Agent {
       `\nCurrent time: ${new Date().toLocaleString()}.` +
       "\nBy default, respond in Traditional Chinese; if the user's query is in English or another language, reply in that language." +
       "\nYou can answer both GDG-related queries and general technical questions. For general technical questions (like comparing technologies or explaining concepts), provide clear, concise answers based on industry best practices, in 3-4 sentences unless more detail is specifically requested." +
-      "\nFor GDG-related queries: Immediately use available tools to retrieve up-to-date information and include relevant links in your responses (no markdown formatting needed)." +
+      "\nFor GDG-related queries: Immediately use available tools to retrieve up-to-date information and include relevant links in your responses (should not be implemented as markdown format)." +
       "\nIf a user's question requires information lookup (such as event details or attendee counts), first use the appropriate tool to search or list events, then use the event name/context to match and fetch details. Never ask the user for technical details such as event IDs, even if the input is ambiguous—always try to resolve it yourself using available tools." +
       "\nIf there are multiple options, make a decision and chain multiple tool calls as needed, providing the final answer directly without asking for clarification." +
       "\nPrioritize function calls over clarifying questions. Do not ask the user for permission to execute functions." +
       "\nKeep responses concise—under 2000 characters for Discord." +
-      "\nMaintain a friendly, professional tone, and feel free to add a bit of light humor occasionally.";
+      "\nMaintain a friendly, professional tone, and feel free to add a bit of light humor occasionally." + 
+      "\nAdd https:// in front of links if they are missing it, so the user can click the URLs directly.";
     return systemInstruction;
   }
 


### PR DESCRIPTION
This pull request aims to make the URLs or links provided by the bot clickable so when users are interacting with the bot, their user experience may be improved. There are several screenshots below to show the effect of the new prompt.

## Old responses by the bot
![image](https://github.com/user-attachments/assets/d9d5b62a-5e79-42d5-a850-ad4759e14b3c)
![image](https://github.com/user-attachments/assets/2026580c-7a25-4a30-acd4-559ec3173385)
![image](https://github.com/user-attachments/assets/753e918d-d88a-41ff-97a7-d104f8830e0b)

## After modifying the prompt
![image](https://github.com/user-attachments/assets/5e574ca1-7b77-4ba8-80de-f9b6ea644eed)
![image](https://github.com/user-attachments/assets/448fbc73-f912-442a-b7e8-5a0f18c6492f)
